### PR TITLE
Add Read Access for Users on the COOL VPN

### DIFF
--- a/remote_states.tf
+++ b/remote_states.tf
@@ -34,6 +34,36 @@ data "terraform_remote_state" "images_staging" {
   workspace = "staging"
 }
 
+data "terraform_remote_state" "sharedservices_networking_production" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-sharedservices-networking/terraform.tfstate"
+  }
+
+  workspace = "production"
+}
+
+data "terraform_remote_state" "sharedservices_networking_staging" {
+  backend = "s3"
+
+  config = {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "cool-sharedservices-networking/terraform.tfstate"
+  }
+
+  workspace = "staging"
+}
+
 data "terraform_remote_state" "terraform" {
   backend = "s3"
 

--- a/vpc_read_policy.tf
+++ b/vpc_read_policy.tf
@@ -21,6 +21,13 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
         data.terraform_remote_state.sharedservices_networking_production.outputs.vpc_endpoint_s3.id,
       ]
     }
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "*",
+      ]
+    }
   }
 
   statement {
@@ -37,6 +44,13 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
 
       values = [
         data.terraform_remote_state.sharedservices_networking_production.outputs.vpc_endpoint_s3.id,
+      ]
+    }
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "*",
       ]
     }
   }
@@ -59,6 +73,13 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_staging" {
         data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc_endpoint_s3.id,
       ]
     }
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "*",
+      ]
+    }
   }
 
   statement {
@@ -75,6 +96,13 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_staging" {
 
       values = [
         data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc_endpoint_s3.id,
+      ]
+    }
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "*",
       ]
     }
   }

--- a/vpc_read_policy.tf
+++ b/vpc_read_policy.tf
@@ -15,10 +15,10 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
 
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceVpc"
+      variable = "aws:SourceVpce"
 
       values = [
-        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc.id,
+        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc_endpoint_s3.id,
       ]
     }
   }
@@ -33,10 +33,10 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
 
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceVpc"
+      variable = "aws:SourceVpce"
 
       values = [
-        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc.id,
+        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc_endpoint_s3.id,
       ]
     }
   }
@@ -53,10 +53,10 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_staging" {
 
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceVpc"
+      variable = "aws:SourceVpce"
 
       values = [
-        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc.id,
+        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc_endpoint_s3.id,
       ]
     }
   }
@@ -71,10 +71,10 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_staging" {
 
     condition {
       test     = "StringEquals"
-      variable = "aws:SourceVpc"
+      variable = "aws:SourceVpce"
 
       values = [
-        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc.id,
+        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc_endpoint_s3.id,
       ]
     }
   }

--- a/vpc_read_policy.tf
+++ b/vpc_read_policy.tf
@@ -1,0 +1,95 @@
+# ------------------------------------------------------------------------------
+# Create the S3 bucket policies that allow read access to the assessment images
+# buckets in the Images (Production) and Images (Staging) accounts from the VPCs
+# for their respective workspaces.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.production.arn
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpc"
+
+      values = [
+        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc.id,
+      ]
+    }
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.production.arn}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpc"
+
+      values = [
+        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc.id,
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "vpcreadaccess_policy_staging" {
+  statement {
+    actions = [
+      "s3:ListBucket",
+    ]
+    resources = [
+      aws_s3_bucket.staging.arn
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpc"
+
+      values = [
+        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc.id,
+      ]
+    }
+  }
+
+  statement {
+    actions = [
+      "s3:GetObject",
+    ]
+    resources = [
+      "${aws_s3_bucket.staging.arn}/*"
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceVpc"
+
+      values = [
+        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc.id,
+      ]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "vpcreadaccess_policy_production" {
+  provider = aws.images_production
+
+  bucket = aws_s3_bucket.production.id
+  policy = data.aws_iam_policy_document.vpcreadaccess_policy_production.json
+}
+
+resource "aws_s3_bucket_policy" "vpcreadaccess_policy_staging" {
+  provider = aws.images_staging
+
+  bucket = aws_s3_bucket.staging.id
+  policy = data.aws_iam_policy_document.vpcreadaccess_policy_staging.json
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a bucket policy to permit read access for anyone accessing the bucket over the COOL VPN (through the [SharedServices VPC](https://github.com/cisagov/cool-sharedservices-networking)).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This is the last piece of https://github.com/cisagov/cool-system/issues/176 and will allow any COOL users to retrieve assessment images over the VPN.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
First I confirmed that without assuming the `AssessmentImagesBucketFullAccess` role I could not access the bucket contents when on the VPN. Once the changes in https://github.com/cisagov/cool-sharedservices-networking/pull/47 were applied I was able to apply the Terraform here to add the bucket policy. I manually added the appropriate routes to the S3 service to my VPN configuration and connected. Once connected I was able to confirm the ability to list the bucket contents and get an object. I also confirmed that I could not put an object.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
