### PR TITLE
Enforce S3 object ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,16 @@ accounts in the COOL.
 | Name | Version |
 |------|---------|
 | terraform | ~> 1.0 |
-| aws | ~> 3.38 |
+| aws | ~> 3.69 |
 
 ## Providers ##
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.38 |
-| aws.images\_production | ~> 3.38 |
-| aws.images\_staging | ~> 3.38 |
-| aws.users | ~> 3.38 |
+| aws | ~> 3.69 |
+| aws.images\_production | ~> 3.69 |
+| aws.images\_staging | ~> 3.69 |
+| aws.users | ~> 3.69 |
 | terraform | n/a |
 
 ## Modules ##
@@ -66,6 +66,8 @@ accounts in the COOL.
 | [aws_iam_user_policy_attachment.assume_bucket_fullaccess_roles](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_s3_bucket.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_ownership_controls.staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.vpcreadaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.vpcreadaccess_policy_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/assessment_images_bucket.tf
+++ b/assessment_images_bucket.tf
@@ -41,6 +41,19 @@ resource "aws_s3_bucket_public_access_block" "production" {
   restrict_public_buckets = true
 }
 
+# This ensures every object in the bucket is owned by the bucket owner. This
+# also disables access control lists (ACLs) and only allows access through
+# policies (such as IAM policies).
+resource "aws_s3_bucket_ownership_controls" "production" {
+  provider = aws.images_production
+
+  bucket = aws_s3_bucket.production.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
 resource "aws_s3_bucket" "staging" {
   provider = aws.images_staging
   # Until this policy attachment happens, we don't have permission
@@ -78,4 +91,17 @@ resource "aws_s3_bucket_public_access_block" "staging" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+# This ensures every object in the bucket is owned by the bucket owner. This
+# also disables access control lists (ACLs) and only allows access through
+# policies (such as IAM policies).
+resource "aws_s3_bucket_ownership_controls" "staging" {
+  provider = aws.images_staging
+
+  bucket = aws_s3_bucket.staging.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 3.69"
     }
   }
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a control for each of the assessment images buckets to enforce the bucket owner as the owner of all objects in the bucket. This disables access control lists (ACLs) and forces the usage of policies (such as IAM policies) to provide access to bucket objects. You can read more about this feature on the [announcement](https://aws.amazon.com/about-aws/whats-new/2021/11/amazon-s3-object-ownership-simplify-access-management-data-s3/).

The version pin of the AWS provider has been bumped to the version ([link](https://github.com/hashicorp/terraform-provider-aws/issues/21980#issuecomment-990454721)) that introduces support for this feature.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since we do not rely on ACLs for bucket access (and in fact only use policies) it makes sense to enable this feature.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. After applying these changes I confirmed I could still access and retrieve bucket contents when connected to the appropriate VPN without authenticating.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
