### PR TITLE
Update `AssessmentImagesBucketFullAccess` policy permissions

### DIFF
--- a/assessmentimagesbucketfullaccess_policy.tf
+++ b/assessmentimagesbucketfullaccess_policy.tf
@@ -15,10 +15,10 @@ data "aws_iam_policy_document" "fullaccess_policy_production" {
 
   statement {
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectTagging",
       "s3:DeleteObject",
       "s3:DeleteObjectTagging",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
       "s3:PutObject",
       "s3:PutObjectTagging",
     ]
@@ -40,10 +40,10 @@ data "aws_iam_policy_document" "fullaccess_policy_staging" {
 
   statement {
     actions = [
-      "s3:GetObject",
-      "s3:GetObjectTagging",
       "s3:DeleteObject",
       "s3:DeleteObjectTagging",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
       "s3:PutObject",
       "s3:PutObjectTagging",
     ]

--- a/assessmentimagesbucketfullaccess_policy.tf
+++ b/assessmentimagesbucketfullaccess_policy.tf
@@ -16,8 +16,11 @@ data "aws_iam_policy_document" "fullaccess_policy_production" {
   statement {
     actions = [
       "s3:GetObject",
+      "s3:GetObjectTagging",
       "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
       "s3:PutObject",
+      "s3:PutObjectTagging",
     ]
     resources = [
       "${aws_s3_bucket.production.arn}/*"
@@ -38,8 +41,11 @@ data "aws_iam_policy_document" "fullaccess_policy_staging" {
   statement {
     actions = [
       "s3:GetObject",
+      "s3:GetObjectTagging",
       "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
       "s3:PutObject",
+      "s3:PutObjectTagging",
     ]
     resources = [
       "${aws_s3_bucket.staging.arn}/*"

--- a/assessmentimagesbucketfullaccess_policy.tf
+++ b/assessmentimagesbucketfullaccess_policy.tf
@@ -7,6 +7,7 @@ data "aws_iam_policy_document" "fullaccess_policy_production" {
   statement {
     actions = [
       "s3:ListBucket",
+      "s3:ListBucketVersions",
     ]
     resources = [
       aws_s3_bucket.production.arn
@@ -19,6 +20,7 @@ data "aws_iam_policy_document" "fullaccess_policy_production" {
       "s3:DeleteObjectTagging",
       "s3:GetObject",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
       "s3:PutObject",
       "s3:PutObjectTagging",
     ]
@@ -32,6 +34,7 @@ data "aws_iam_policy_document" "fullaccess_policy_staging" {
   statement {
     actions = [
       "s3:ListBucket",
+      "s3:ListBucketVersions",
     ]
     resources = [
       aws_s3_bucket.staging.arn
@@ -44,6 +47,7 @@ data "aws_iam_policy_document" "fullaccess_policy_staging" {
       "s3:DeleteObjectTagging",
       "s3:GetObject",
       "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
       "s3:PutObject",
       "s3:PutObjectTagging",
     ]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the permissions for the `AssessmentImagesBucketFullAccess` policies to support managing the tag-sets applied to bucket objects and the ability to view and copy versions of bucket objects.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since this policy is going to be used by individuals (using [cisagov/cool-assessment-images-manager-iam](https://github.com/cisagov/cool-assessment-images-manager-iam)) instead of a service user it makes sense to enhance the functionality. Managing object tag-sets is helpful, but the main focus is on allowing someone to use this policy to copy a previous version of an object in case a roll-back or testing against a previous version is required.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that before applying this change I could neither access object versions nor copy a previous version of an object. Once this configuration was applied I was able to copy a previous version of an object to a new key.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
