### PR TITLE
Update configuration to be Terraform workspace specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![GitHub Build Status](https://github.com/cisagov/cool-images-assessment-images/workflows/build/badge.svg)](https://github.com/cisagov/cool-images-assessment-images/actions)
 
 Terraform code to create a role related to the creation of and access to an S3
-bucket to house assessment images in the Images (Production) account in the
-COOL.
+bucket to house assessment images in the Images account in the COOL.
 
 ## Pre-requisites ##
 
@@ -16,7 +15,7 @@ COOL.
 - Access to all of the Terraform remote states specified in
   [remote_states.tf](remote_states.tf).
 - The following COOL accounts and roles must have been created:
-  - Images (Production and Staging):
+  - Images:
     [`cisagov/cool-accounts/images`](https://github.com/cisagov/cool-accounts/tree/develop/images)
   - Terraform:
     [`cisagov/cool-accounts/terraform`](https://github.com/cisagov/cool-accounts/tree/develop/terraform)
@@ -35,7 +34,7 @@ COOL.
 | Name | Version |
 |------|---------|
 | aws | ~> 3.69 |
-| aws.images\_production | ~> 3.69 |
+| aws.images | ~> 3.69 |
 | aws.users | ~> 3.69 |
 | terraform | n/a |
 
@@ -49,23 +48,23 @@ COOL.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.fullaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.provision_bucket_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.fullaccess_role_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.fullaccess_role_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.provision_bucket_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_s3_bucket.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_ownership_controls.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
-| [aws_s3_bucket_policy.vpcreadaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_iam_policy.fullaccess_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.provision_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.fullaccess_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.fullaccess_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.provision_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_s3_bucket.assessment_images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_ownership_controls.assessment_images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.vpcreadaccess_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.assessment_images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.fullaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.provision_bucket_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vpcreadaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [terraform_remote_state.images_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.sharedservices_networking_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [aws_iam_policy_document.fullaccess_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.provision_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vpcreadaccess_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [terraform_remote_state.images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.sharedservices_networking](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -73,7 +72,7 @@ COOL.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| assessment\_images\_bucket\_base\_name | The base name to use for the assessment images S3 bucket. This value will be appended with "-production" to create the appropriate full bucket name (e.g. With the default value "cisa-cool-assessment-images-production" will be used for the bucket in the Images (Production) account). | `string` | `"cisa-cool-assessment-images"` | no |
+| assessment\_images\_bucket\_base\_name | The base name to use for the assessment images S3 bucket. This value will have the current workspace appended to create the appropriate full bucket name (e.g. With the default value "cisa-cool-assessment-images-production" will be used for the bucket in the production workspace). | `string` | `"cisa-cool-assessment-images"` | no |
 | assessmentimagesbucketfullaccess\_role\_description | The description to associate with the IAM role and attached policy that allows full access to the assessment images S3 bucket. | `string` | `"Allows full access to the S3 bucket where assessment images are stored."` | no |
 | assessmentimagesbucketfullaccess\_role\_name | The name to associate with the IAM role and attached policy that allows full access to the assessment images S3 bucket. | `string` | `"AssessmentImagesBucketFullAccess"` | no |
 | aws\_region | The AWS region to use for the account provisioners (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
@@ -86,8 +85,8 @@ COOL.
 
 | Name | Description |
 |------|-------------|
-| assessment\_images\_bucket\_production | The S3 bucket to store assessment images in the Images (Production) account. |
-| assessmentimagesbucketfullaccess\_role\_production | The IAM role that allows full access to the assessment images bucket in the Images (Production) account. |
+| assessment\_images\_bucket | The S3 bucket to store assessment images. |
+| assessmentimagesbucketfullaccess\_role | The IAM role that allows full access to the assessment images bucket. |
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-images-assessment-images state in the Terraform state bucket. |
 
 ## Notes ##

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![GitHub Build Status](https://github.com/cisagov/cool-images-assessment-images/workflows/build/badge.svg)](https://github.com/cisagov/cool-images-assessment-images/actions)
 
-Terraform code to create a role related to the creation of and access to an S3
-bucket to house assessment images in the Images account in the COOL.
+Terraform code to create the resources necessary to provide an S3 bucket to
+house assessment images. This includes an S3 bucket in the Images account, a
+role to manage the bucket, and a policy to allow read access when accessing
+the bucket through the VPC in the Shared Services account.
 
 ## Pre-requisites ##
 
@@ -17,10 +19,15 @@ bucket to house assessment images in the Images account in the COOL.
 - The following COOL accounts and roles must have been created:
   - Images:
     [`cisagov/cool-accounts/images`](https://github.com/cisagov/cool-accounts/tree/develop/images)
+  - Shared Services:
+    [`cisagov/cool-accounts/shared-services`](https://github.com/cisagov/cool-accounts/tree/develop/shared-services)
   - Terraform:
     [`cisagov/cool-accounts/terraform`](https://github.com/cisagov/cool-accounts/tree/develop/terraform)
   - Users:
     [`cisagov/cool-accounts/users`](https://github.com/cisagov/cool-accounts/tree/develop/users)
+- Terraform in
+  [`cisagov/cool-sharedservices-networking`](https://github.com/cisagov/cool-sharedservices-networking)
+  must have been applied.
 
 ## Requirements ##
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![GitHub Build Status](https://github.com/cisagov/cool-images-assessment-images/workflows/build/badge.svg)](https://github.com/cisagov/cool-images-assessment-images/actions)
 
-Terraform code to create roles related to the creation of and access to buckets
-to house assessment images in the Images (Production) and Images (Staging)
-accounts in the COOL.
+Terraform code to create a role related to the creation of and access to an S3
+bucket to house assessment images in the Images (Production) account in the
+COOL.
 
 ## Pre-requisites ##
 
@@ -36,7 +36,6 @@ accounts in the COOL.
 |------|---------|
 | aws | ~> 3.69 |
 | aws.images\_production | ~> 3.69 |
-| aws.images\_staging | ~> 3.69 |
 | aws.users | ~> 3.69 |
 | terraform | n/a |
 
@@ -51,36 +50,22 @@ accounts in the COOL.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.fullaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.fullaccess_policy_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.provision_bucket_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.provision_bucket_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.fullaccess_role_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.fullaccess_role_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.fullaccess_role_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.fullaccess_role_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.provision_bucket_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.provision_bucket_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_s3_bucket.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_ownership_controls.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
-| [aws_s3_bucket_ownership_controls.staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.vpcreadaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_policy.vpcreadaccess_policy_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_caller_identity.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fullaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.fullaccess_policy_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.provision_bucket_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.provision_bucket_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vpcreadaccess_policy_production](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vpcreadaccess_policy_staging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [terraform_remote_state.images_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.images_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.sharedservices_networking_production](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
-| [terraform_remote_state.sharedservices_networking_staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.terraform](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -88,7 +73,7 @@ accounts in the COOL.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| assessment\_images\_bucket\_base\_name | The base name to use for the assessment images S3 buckets. This value will be appended with "-production" or "-staging" to create the appropriate full bucket name (e.g. With the default value "cisa-cool-assessment-images-production" will be used for the bucket in the Images (Production) account). | `string` | `"cisa-cool-assessment-images"` | no |
+| assessment\_images\_bucket\_base\_name | The base name to use for the assessment images S3 bucket. This value will be appended with "-production" to create the appropriate full bucket name (e.g. With the default value "cisa-cool-assessment-images-production" will be used for the bucket in the Images (Production) account). | `string` | `"cisa-cool-assessment-images"` | no |
 | assessmentimagesbucketfullaccess\_role\_description | The description to associate with the IAM role and attached policy that allows full access to the assessment images S3 bucket. | `string` | `"Allows full access to the S3 bucket where assessment images are stored."` | no |
 | assessmentimagesbucketfullaccess\_role\_name | The name to associate with the IAM role and attached policy that allows full access to the assessment images S3 bucket. | `string` | `"AssessmentImagesBucketFullAccess"` | no |
 | aws\_region | The AWS region to use for the account provisioners (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
@@ -102,9 +87,7 @@ accounts in the COOL.
 | Name | Description |
 |------|-------------|
 | assessment\_images\_bucket\_production | The S3 bucket to store assessment images in the Images (Production) account. |
-| assessment\_images\_bucket\_staging | The S3 bucket to store assessment images in the Images (Staging) account. |
 | assessmentimagesbucketfullaccess\_role\_production | The IAM role that allows full access to the assessment images bucket in the Images (Production) account. |
-| assessmentimagesbucketfullaccess\_role\_staging | The IAM role that allows full access to the assessment images bucket in the Images (Staging) account. |
 | read\_terraform\_state | The IAM policies and role that allow read-only access to the cool-images-assessment-images state in the Terraform state bucket. |
 
 ## Notes ##

--- a/assessment_images_bucket.tf
+++ b/assessment_images_bucket.tf
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Create S3 buckets to store assessment images.
+# Create an S3 bucket to store assessment images.
 # ------------------------------------------------------------------------------
 
 resource "aws_s3_bucket" "production" {
@@ -48,58 +48,6 @@ resource "aws_s3_bucket_ownership_controls" "production" {
   provider = aws.images_production
 
   bucket = aws_s3_bucket.production.id
-
-  rule {
-    object_ownership = "BucketOwnerEnforced"
-  }
-}
-
-resource "aws_s3_bucket" "staging" {
-  provider = aws.images_staging
-  # Until this policy attachment happens, we don't have permission
-  # to provision the bucket.
-  depends_on = [
-    aws_iam_role_policy_attachment.provision_bucket_staging
-  ]
-
-  acl    = "private"
-  bucket = local.staging_bucket_name
-
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  tags = { "Workspace" = "staging" }
-
-  versioning {
-    enabled = true
-  }
-}
-
-# This blocks ANY public access to the bucket or the objects it
-# contains, even if misconfigured to allow public access.
-resource "aws_s3_bucket_public_access_block" "staging" {
-  provider = aws.images_staging
-
-  bucket = aws_s3_bucket.staging.id
-
-  block_public_acls       = true
-  block_public_policy     = true
-  ignore_public_acls      = true
-  restrict_public_buckets = true
-}
-
-# This ensures every object in the bucket is owned by the bucket owner. This
-# also disables access control lists (ACLs) and only allows access through
-# policies (such as IAM policies).
-resource "aws_s3_bucket_ownership_controls" "staging" {
-  provider = aws.images_staging
-
-  bucket = aws_s3_bucket.staging.id
 
   rule {
     object_ownership = "BucketOwnerEnforced"

--- a/assessment_images_bucket.tf
+++ b/assessment_images_bucket.tf
@@ -2,16 +2,16 @@
 # Create an S3 bucket to store assessment images.
 # ------------------------------------------------------------------------------
 
-resource "aws_s3_bucket" "production" {
-  provider = aws.images_production
+resource "aws_s3_bucket" "assessment_images" {
+  provider = aws.images
   # Until this policy attachment happens, we don't have permission
   # to provision the bucket.
   depends_on = [
-    aws_iam_role_policy_attachment.provision_bucket_production
+    aws_iam_role_policy_attachment.provision_bucket
   ]
 
   acl    = "private"
-  bucket = local.production_bucket_name
+  bucket = local.bucket_name
 
   server_side_encryption_configuration {
     rule {
@@ -21,8 +21,6 @@ resource "aws_s3_bucket" "production" {
     }
   }
 
-  tags = { "Workspace" = "production" }
-
   versioning {
     enabled = true
   }
@@ -30,10 +28,10 @@ resource "aws_s3_bucket" "production" {
 
 # This blocks ANY public access to the bucket or the objects it
 # contains, even if misconfigured to allow public access.
-resource "aws_s3_bucket_public_access_block" "production" {
-  provider = aws.images_production
+resource "aws_s3_bucket_public_access_block" "assessment_images" {
+  provider = aws.images
 
-  bucket = aws_s3_bucket.production.id
+  bucket = aws_s3_bucket.assessment_images.id
 
   block_public_acls       = true
   block_public_policy     = true
@@ -44,10 +42,10 @@ resource "aws_s3_bucket_public_access_block" "production" {
 # This ensures every object in the bucket is owned by the bucket owner. This
 # also disables access control lists (ACLs) and only allows access through
 # policies (such as IAM policies).
-resource "aws_s3_bucket_ownership_controls" "production" {
-  provider = aws.images_production
+resource "aws_s3_bucket_ownership_controls" "assessment_images" {
+  provider = aws.images
 
-  bucket = aws_s3_bucket.production.id
+  bucket = aws_s3_bucket.assessment_images.id
 
   rule {
     object_ownership = "BucketOwnerEnforced"

--- a/assessmentimagesbucketfullaccess_policy.tf
+++ b/assessmentimagesbucketfullaccess_policy.tf
@@ -1,16 +1,15 @@
 # ------------------------------------------------------------------------------
-# Create the IAM policy that allows full access to the assessment images
-# bucket in the Images (Production) account.
+# Create the IAM policy that allows full access to the assessment images bucket.
 # ------------------------------------------------------------------------------
 
-data "aws_iam_policy_document" "fullaccess_policy_production" {
+data "aws_iam_policy_document" "fullaccess_policy" {
   statement {
     actions = [
       "s3:ListBucket",
       "s3:ListBucketVersions",
     ]
     resources = [
-      aws_s3_bucket.production.arn
+      aws_s3_bucket.assessment_images.arn
     ]
   }
 
@@ -25,15 +24,15 @@ data "aws_iam_policy_document" "fullaccess_policy_production" {
       "s3:PutObjectTagging",
     ]
     resources = [
-      "${aws_s3_bucket.production.arn}/*"
+      "${aws_s3_bucket.assessment_images.arn}/*"
     ]
   }
 }
 
-resource "aws_iam_policy" "fullaccess_policy_production" {
-  provider = aws.images_production
+resource "aws_iam_policy" "fullaccess_policy" {
+  provider = aws.images
 
   description = var.assessmentimagesbucketfullaccess_role_description
   name        = var.assessmentimagesbucketfullaccess_role_name
-  policy      = data.aws_iam_policy_document.fullaccess_policy_production.json
+  policy      = data.aws_iam_policy_document.fullaccess_policy.json
 }

--- a/assessmentimagesbucketfullaccess_policy.tf
+++ b/assessmentimagesbucketfullaccess_policy.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
-# Create the IAM policies that allow full access to the assessment images
-# buckets in the Images (Production) and Images (Staging) accounts.
+# Create the IAM policy that allows full access to the assessment images
+# bucket in the Images (Production) account.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "fullaccess_policy_production" {
@@ -30,45 +30,10 @@ data "aws_iam_policy_document" "fullaccess_policy_production" {
   }
 }
 
-data "aws_iam_policy_document" "fullaccess_policy_staging" {
-  statement {
-    actions = [
-      "s3:ListBucket",
-      "s3:ListBucketVersions",
-    ]
-    resources = [
-      aws_s3_bucket.staging.arn
-    ]
-  }
-
-  statement {
-    actions = [
-      "s3:DeleteObject",
-      "s3:DeleteObjectTagging",
-      "s3:GetObject",
-      "s3:GetObjectTagging",
-      "s3:GetObjectVersion",
-      "s3:PutObject",
-      "s3:PutObjectTagging",
-    ]
-    resources = [
-      "${aws_s3_bucket.staging.arn}/*"
-    ]
-  }
-}
-
 resource "aws_iam_policy" "fullaccess_policy_production" {
   provider = aws.images_production
 
   description = var.assessmentimagesbucketfullaccess_role_description
   name        = var.assessmentimagesbucketfullaccess_role_name
   policy      = data.aws_iam_policy_document.fullaccess_policy_production.json
-}
-
-resource "aws_iam_policy" "fullaccess_policy_staging" {
-  provider = aws.images_staging
-
-  description = var.assessmentimagesbucketfullaccess_role_description
-  name        = var.assessmentimagesbucketfullaccess_role_name
-  policy      = data.aws_iam_policy_document.fullaccess_policy_staging.json
 }

--- a/assessmentimagesbucketfullaccess_role.tf
+++ b/assessmentimagesbucketfullaccess_role.tf
@@ -1,20 +1,18 @@
 # ------------------------------------------------------------------------------
-# Create the IAM roles that allow full access to the assessment images
-# bucket in the Images (Production) account.
+# Create the IAM roles that allow full access to the assessment images bucket.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role" "fullaccess_role_production" {
-  provider = aws.images_production
+resource "aws_iam_role" "fullaccess_role" {
+  provider = aws.images
 
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
   description        = var.assessmentimagesbucketfullaccess_role_description
   name               = var.assessmentimagesbucketfullaccess_role_name
-  tags               = { "Workspace" = "production" }
 }
 
-resource "aws_iam_role_policy_attachment" "fullaccess_role_production" {
-  provider = aws.images_production
+resource "aws_iam_role_policy_attachment" "fullaccess_role" {
+  provider = aws.images
 
-  policy_arn = aws_iam_policy.fullaccess_policy_production.arn
-  role       = aws_iam_role.fullaccess_role_production.name
+  policy_arn = aws_iam_policy.fullaccess_policy.arn
+  role       = aws_iam_role.fullaccess_role.name
 }

--- a/assessmentimagesbucketfullaccess_role.tf
+++ b/assessmentimagesbucketfullaccess_role.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM roles that allow full access to the assessment images
-# buckets in the Images (Production) and Images (Staging) accounts.
+# bucket in the Images (Production) account.
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role" "fullaccess_role_production" {
@@ -17,20 +17,4 @@ resource "aws_iam_role_policy_attachment" "fullaccess_role_production" {
 
   policy_arn = aws_iam_policy.fullaccess_policy_production.arn
   role       = aws_iam_role.fullaccess_role_production.name
-}
-
-resource "aws_iam_role" "fullaccess_role_staging" {
-  provider = aws.images_staging
-
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
-  description        = var.assessmentimagesbucketfullaccess_role_description
-  name               = var.assessmentimagesbucketfullaccess_role_name
-  tags               = { "Workspace" = "staging" }
-}
-
-resource "aws_iam_role_policy_attachment" "fullaccess_role_staging" {
-  provider = aws.images_staging
-
-  policy_arn = aws_iam_policy.fullaccess_policy_staging.arn
-  role       = aws_iam_role.fullaccess_role_staging.name
 }

--- a/assume_role_policy_doc.tf
+++ b/assume_role_policy_doc.tf
@@ -1,6 +1,5 @@
 # ------------------------------------------------------------------------------
-# Create an IAM policy document that allows the Users account to
-# assume this role.
+# Create an IAM policy document that allows the Users account to assume a role.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "assume_role" {

--- a/locals.tf
+++ b/locals.tf
@@ -24,10 +24,6 @@ locals {
   # account.
   production_bucket_name = format("%s-production", var.assessment_images_bucket_base_name)
 
-  # Format the base bucket name into the name to use in the Images (Staging)
-  # account.
-  staging_bucket_name = format("%s-staging", var.assessment_images_bucket_base_name)
-
   # The account ID for the Users account
   users_account_id = data.aws_caller_identity.users.account_id
 }

--- a/locals.tf
+++ b/locals.tf
@@ -20,9 +20,8 @@ locals {
   # as assume role session names.
   caller_user_name = split("/", data.aws_caller_identity.current.arn)[1]
 
-  # Format the base bucket name into the name to use in the Images (Production)
-  # account.
-  production_bucket_name = format("%s-production", var.assessment_images_bucket_base_name)
+  # Format the base bucket name into the name to use in the current workspace.
+  bucket_name = format("%s-%s", var.assessment_images_bucket_base_name, terraform.workspace)
 
   # The account ID for the Users account
   users_account_id = data.aws_caller_identity.users.account_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,19 +3,9 @@ output "assessment_images_bucket_production" {
   description = "The S3 bucket to store assessment images in the Images (Production) account."
 }
 
-output "assessment_images_bucket_staging" {
-  value       = aws_s3_bucket.staging
-  description = "The S3 bucket to store assessment images in the Images (Staging) account."
-}
-
 output "assessmentimagesbucketfullaccess_role_production" {
   value       = aws_iam_role.fullaccess_role_production
   description = "The IAM role that allows full access to the assessment images bucket in the Images (Production) account."
-}
-
-output "assessmentimagesbucketfullaccess_role_staging" {
-  value       = aws_iam_role.fullaccess_role_staging
-  description = "The IAM role that allows full access to the assessment images bucket in the Images (Staging) account."
 }
 
 output "read_terraform_state" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,11 @@
-output "assessment_images_bucket_production" {
-  value       = aws_s3_bucket.production
-  description = "The S3 bucket to store assessment images in the Images (Production) account."
+output "assessment_images_bucket" {
+  value       = aws_s3_bucket.assessment_images
+  description = "The S3 bucket to store assessment images."
 }
 
-output "assessmentimagesbucketfullaccess_role_production" {
-  value       = aws_iam_role.fullaccess_role_production
-  description = "The IAM role that allows full access to the assessment images bucket in the Images (Production) account."
+output "assessmentimagesbucketfullaccess_role" {
+  value       = aws_iam_role.fullaccess_role
+  description = "The IAM role that allows full access to the assessment images bucket."
 }
 
 output "read_terraform_state" {

--- a/providers.tf
+++ b/providers.tf
@@ -7,11 +7,11 @@ provider "aws" {
 }
 
 # The provider used to create the role that can be assumed to do everything
-# needed in the Images (Production) account.
+# needed in the Images account.
 provider "aws" {
-  alias = "images_production"
+  alias = "images"
   assume_role {
-    role_arn     = data.terraform_remote_state.images_production.outputs.provisionaccount_role.arn
+    role_arn     = data.terraform_remote_state.images.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
   default_tags {

--- a/providers.tf
+++ b/providers.tf
@@ -20,20 +20,6 @@ provider "aws" {
   region = var.aws_region
 }
 
-# The provider used to create the role that can be assumed to do everything
-# needed in the Images (Staging) account.
-provider "aws" {
-  alias = "images_staging"
-  assume_role {
-    role_arn     = data.terraform_remote_state.images_staging.outputs.provisionaccount_role.arn
-    session_name = local.caller_user_name
-  }
-  default_tags {
-    tags = var.tags
-  }
-  region = var.aws_region
-}
-
 # The provider used to create resources inside the Terraform account.
 provider "aws" {
   alias = "terraform"

--- a/provisionassessmentimagesbucket_policy.tf
+++ b/provisionassessmentimagesbucket_policy.tf
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policy that allows provisioning of the assessment images bucket
-# in the Images (Production) and Images (Staging) accounts.
+# in the Images (Production) account.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "provision_bucket_production" {
@@ -15,30 +15,10 @@ data "aws_iam_policy_document" "provision_bucket_production" {
   }
 }
 
-data "aws_iam_policy_document" "provision_bucket_staging" {
-  statement {
-    actions = [
-      "s3:*",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${local.staging_bucket_name}"
-    ]
-  }
-}
-
 resource "aws_iam_policy" "provision_bucket_production" {
   provider = aws.images_production
 
   description = var.provisionassessmentimagesbucket_policy_description
   name        = var.provisionassessmentimagesbucket_policy_name
   policy      = data.aws_iam_policy_document.provision_bucket_production.json
-}
-
-resource "aws_iam_policy" "provision_bucket_staging" {
-  provider = aws.images_staging
-
-  description = var.provisionassessmentimagesbucket_policy_description
-  name        = var.provisionassessmentimagesbucket_policy_name
-  policy      = data.aws_iam_policy_document.provision_bucket_staging.json
 }

--- a/provisionassessmentimagesbucket_policy.tf
+++ b/provisionassessmentimagesbucket_policy.tf
@@ -1,24 +1,24 @@
 # ------------------------------------------------------------------------------
 # Create the IAM policy that allows provisioning of the assessment images bucket
-# in the Images (Production) account.
+# in the Images account for the current workspace.
 # ------------------------------------------------------------------------------
 
-data "aws_iam_policy_document" "provision_bucket_production" {
+data "aws_iam_policy_document" "provision_bucket" {
   statement {
     actions = [
       "s3:*",
     ]
 
     resources = [
-      "arn:aws:s3:::${local.production_bucket_name}"
+      "arn:aws:s3:::${local.bucket_name}"
     ]
   }
 }
 
-resource "aws_iam_policy" "provision_bucket_production" {
-  provider = aws.images_production
+resource "aws_iam_policy" "provision_bucket" {
+  provider = aws.images
 
   description = var.provisionassessmentimagesbucket_policy_description
   name        = var.provisionassessmentimagesbucket_policy_name
-  policy      = data.aws_iam_policy_document.provision_bucket_production.json
+  policy      = data.aws_iam_policy_document.provision_bucket.json
 }

--- a/provisionassessmentimagesbucket_policy_attachment.tf
+++ b/provisionassessmentimagesbucket_policy_attachment.tf
@@ -1,7 +1,6 @@
 # ------------------------------------------------------------------------------
 # Attach to the ProvisionAccount role the IAM policy that allows provisioning of
-# the assessment images bucket in the Images (Production) and Images (Staging)
-# accounts.
+# the assessment images bucket in the Images (Production) account.
 # ------------------------------------------------------------------------------
 
 resource "aws_iam_role_policy_attachment" "provision_bucket_production" {
@@ -9,11 +8,4 @@ resource "aws_iam_role_policy_attachment" "provision_bucket_production" {
 
   policy_arn = aws_iam_policy.provision_bucket_production.arn
   role       = data.terraform_remote_state.images_production.outputs.provisionaccount_role.name
-}
-
-resource "aws_iam_role_policy_attachment" "provision_bucket_staging" {
-  provider = aws.images_staging
-
-  policy_arn = aws_iam_policy.provision_bucket_staging.arn
-  role       = data.terraform_remote_state.images_staging.outputs.provisionaccount_role.name
 }

--- a/provisionassessmentimagesbucket_policy_attachment.tf
+++ b/provisionassessmentimagesbucket_policy_attachment.tf
@@ -1,11 +1,11 @@
 # ------------------------------------------------------------------------------
 # Attach to the ProvisionAccount role the IAM policy that allows provisioning of
-# the assessment images bucket in the Images (Production) account.
+# the assessment images bucket in the Images account for the current workspace.
 # ------------------------------------------------------------------------------
 
-resource "aws_iam_role_policy_attachment" "provision_bucket_production" {
-  provider = aws.images_production
+resource "aws_iam_role_policy_attachment" "provision_bucket" {
+  provider = aws.images
 
-  policy_arn = aws_iam_policy.provision_bucket_production.arn
-  role       = data.terraform_remote_state.images_production.outputs.provisionaccount_role.name
+  policy_arn = aws_iam_policy.provision_bucket.arn
+  role       = data.terraform_remote_state.images.outputs.provisionaccount_role.name
 }

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -4,7 +4,7 @@
 # for this configuration.
 # ------------------------------------------------------------------------------
 
-data "terraform_remote_state" "images_production" {
+data "terraform_remote_state" "images" {
   backend = "s3"
 
   config = {
@@ -16,10 +16,10 @@ data "terraform_remote_state" "images_production" {
     key            = "cool-accounts/images.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
-data "terraform_remote_state" "sharedservices_networking_production" {
+data "terraform_remote_state" "sharedservices_networking" {
   backend = "s3"
 
   config = {
@@ -31,7 +31,7 @@ data "terraform_remote_state" "sharedservices_networking_production" {
     key            = "cool-sharedservices-networking/terraform.tfstate"
   }
 
-  workspace = "production"
+  workspace = terraform.workspace
 }
 
 data "terraform_remote_state" "terraform" {

--- a/remote_states.tf
+++ b/remote_states.tf
@@ -19,21 +19,6 @@ data "terraform_remote_state" "images_production" {
   workspace = "production"
 }
 
-data "terraform_remote_state" "images_staging" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-accounts/images.tfstate"
-  }
-
-  workspace = "staging"
-}
-
 data "terraform_remote_state" "sharedservices_networking_production" {
   backend = "s3"
 
@@ -47,21 +32,6 @@ data "terraform_remote_state" "sharedservices_networking_production" {
   }
 
   workspace = "production"
-}
-
-data "terraform_remote_state" "sharedservices_networking_staging" {
-  backend = "s3"
-
-  config = {
-    encrypt        = true
-    bucket         = "cisa-cool-terraform-state"
-    dynamodb_table = "terraform-state-lock"
-    profile        = "cool-terraform-backend"
-    region         = "us-east-1"
-    key            = "cool-sharedservices-networking/terraform.tfstate"
-  }
-
-  workspace = "staging"
 }
 
 data "terraform_remote_state" "terraform" {

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 variable "assessment_images_bucket_base_name" {
   type        = string
-  description = "The base name to use for the assessment images S3 buckets. This value will be appended with \"-production\" or \"-staging\" to create the appropriate full bucket name (e.g. With the default value \"cisa-cool-assessment-images-production\" will be used for the bucket in the Images (Production) account)."
+  description = "The base name to use for the assessment images S3 bucket. This value will be appended with \"-production\" to create the appropriate full bucket name (e.g. With the default value \"cisa-cool-assessment-images-production\" will be used for the bucket in the Images (Production) account)."
   default     = "cisa-cool-assessment-images"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 variable "assessment_images_bucket_base_name" {
   type        = string
-  description = "The base name to use for the assessment images S3 bucket. This value will be appended with \"-production\" to create the appropriate full bucket name (e.g. With the default value \"cisa-cool-assessment-images-production\" will be used for the bucket in the Images (Production) account)."
+  description = "The base name to use for the assessment images S3 bucket. This value will have the current workspace appended to create the appropriate full bucket name (e.g. With the default value \"cisa-cool-assessment-images-production\" will be used for the bucket in the production workspace)."
   default     = "cisa-cool-assessment-images"
 }
 

--- a/vpc_read_policy.tf
+++ b/vpc_read_policy.tf
@@ -1,16 +1,15 @@
 # ------------------------------------------------------------------------------
 # Create the S3 bucket policy that allows read access to the assessment images
-# bucket in the Images (Production) account from the VPC in the production
-# workspace.
+# bucket in the Images account from the VPC in the Shared Services account.
 # ------------------------------------------------------------------------------
 
-data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
+data "aws_iam_policy_document" "vpcreadaccess_policy" {
   statement {
     actions = [
       "s3:ListBucket",
     ]
     resources = [
-      aws_s3_bucket.production.arn
+      aws_s3_bucket.assessment_images.arn
     ]
 
     condition {
@@ -18,7 +17,7 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
       variable = "aws:SourceVpce"
 
       values = [
-        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc_endpoint_s3.id,
+        data.terraform_remote_state.sharedservices_networking.outputs.vpc_endpoint_s3.id,
       ]
     }
 
@@ -35,7 +34,7 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
       "s3:GetObject",
     ]
     resources = [
-      "${aws_s3_bucket.production.arn}/*"
+      "${aws_s3_bucket.assessment_images.arn}/*"
     ]
 
     condition {
@@ -43,7 +42,7 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
       variable = "aws:SourceVpce"
 
       values = [
-        data.terraform_remote_state.sharedservices_networking_production.outputs.vpc_endpoint_s3.id,
+        data.terraform_remote_state.sharedservices_networking.outputs.vpc_endpoint_s3.id,
       ]
     }
 
@@ -56,9 +55,9 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
   }
 }
 
-resource "aws_s3_bucket_policy" "vpcreadaccess_policy_production" {
-  provider = aws.images_production
+resource "aws_s3_bucket_policy" "vpcreadaccess_policy" {
+  provider = aws.images
 
-  bucket = aws_s3_bucket.production.id
-  policy = data.aws_iam_policy_document.vpcreadaccess_policy_production.json
+  bucket = aws_s3_bucket.assessment_images.id
+  policy = data.aws_iam_policy_document.vpcreadaccess_policy.json
 }

--- a/vpc_read_policy.tf
+++ b/vpc_read_policy.tf
@@ -1,7 +1,7 @@
 # ------------------------------------------------------------------------------
-# Create the S3 bucket policies that allow read access to the assessment images
-# buckets in the Images (Production) and Images (Staging) accounts from the VPCs
-# for their respective workspaces.
+# Create the S3 bucket policy that allows read access to the assessment images
+# bucket in the Images (Production) account from the VPC in the production
+# workspace.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
@@ -56,68 +56,9 @@ data "aws_iam_policy_document" "vpcreadaccess_policy_production" {
   }
 }
 
-data "aws_iam_policy_document" "vpcreadaccess_policy_staging" {
-  statement {
-    actions = [
-      "s3:ListBucket",
-    ]
-    resources = [
-      aws_s3_bucket.staging.arn
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceVpce"
-
-      values = [
-        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc_endpoint_s3.id,
-      ]
-    }
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        "*",
-      ]
-    }
-  }
-
-  statement {
-    actions = [
-      "s3:GetObject",
-    ]
-    resources = [
-      "${aws_s3_bucket.staging.arn}/*"
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceVpce"
-
-      values = [
-        data.terraform_remote_state.sharedservices_networking_staging.outputs.vpc_endpoint_s3.id,
-      ]
-    }
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        "*",
-      ]
-    }
-  }
-}
-
 resource "aws_s3_bucket_policy" "vpcreadaccess_policy_production" {
   provider = aws.images_production
 
   bucket = aws_s3_bucket.production.id
   policy = data.aws_iam_policy_document.vpcreadaccess_policy_production.json
-}
-
-resource "aws_s3_bucket_policy" "vpcreadaccess_policy_staging" {
-  provider = aws.images_staging
-
-  bucket = aws_s3_bucket.staging.id
-  policy = data.aws_iam_policy_document.vpcreadaccess_policy_staging.json
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request separates this configuration to be specific to its Terraform workspace instead of explicitly containing configuration for our Production and Staging environments. This closes #13.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

After the merge of #14 we no longer need to explicitly house Production and Staging resources in the same configuration. This allows us to generalize the configuration to be Terraform workspace specific. Additionally we still have the goal of completely removing any relation between our Production and Staging environments and this updates this configuration in alignment with that goal.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
